### PR TITLE
Add doing_handshake variable to prevent updates or confirms on threads that are still handshaking

### DIFF
--- a/src/pyopticon/_system/_serial_widget.py
+++ b/src/pyopticon/_system/_serial_widget.py
@@ -76,7 +76,13 @@ class SerialWidget:
             return
         for obj in self.parent.all_widgets:
             if hasattr(obj,'queue'):
+                if hasattr(obj,'doing_handshake'):
+                    if obj.doing_handshake:
+                        print("Warning: widget '"+obj.name+"' prompted to update before handshake complete. Ignoring...")
+                        continue
+
                 obj.queue.put(('UPDATE',obj)) #Prompt each widget to update
+                
                 if hasattr(obj,'doing_update'):
                     if obj.doing_update:
                         print("Warning: widget '"+obj.name+"' prompted to update before the previous update cycle finished. Consider polling less often using update_every_n_cycles argument, or else the dashboard may lag.")

--- a/src/pyopticon/generic_widget.py
+++ b/src/pyopticon/generic_widget.py
@@ -447,10 +447,6 @@ class GenericWidget:
         if not self.handshake_was_successful:
             self.on_failed_serial_open()
 
-        # Dump the queue to ignore any queries/confirms that were prompted while the handshake happened
-        with self.queue.mutex:
-            self.queue.queue.clear()
-
 
     def close_serial(self):
         """Closes the serial object, if needed, and returns the GUI fields to their default non-connected states. Executes on_serial_close, which is hopefully implemented in a subclass."""

--- a/src/pyopticon/generic_widget.py
+++ b/src/pyopticon/generic_widget.py
@@ -44,6 +44,7 @@ class GenericWidget:
         self.serial_object = None
 
         # Flag for whether initialization and handshake were successful
+        self.doing_handshake = False
         self.handshake_was_successful = False
 
         # Unpack kwargs
@@ -332,7 +333,9 @@ class GenericWidget:
                             widget._on_confirm()
 
                         elif cmd == 'HANDSHAKE': # Tell the thread to open serial and do the handshake
+                            self.doing_handshake = True
                             widget._handshake()
+                            self.doing_handshake = False
 
                 except Exception as e:
                     self.parent_dashboard.exc_handler(e,'system',self.name)
@@ -380,6 +383,11 @@ class GenericWidget:
         if self.serial_object == None and not (self.no_serial or self.parent_dashboard.offline_mode):
             print("\"Confirm\" pressed for "+str(self.name)+" with no serial connection.")
             return
+        
+        if self.doing_handshake:
+            print("\"Confirm\" pressed for "+str(self.name)+" while still handshaking.")
+            return
+        
         self.queue.put(('CONFIRM',self))
 
     def _on_confirm(self):
@@ -395,7 +403,7 @@ class GenericWidget:
         self._update_cycle_counter%=self.update_every_n_cycles
         if self._update_cycle_counter!=0:
             return
-        if not self.handshake_was_successful:
+        if not self.handshake_was_successful or self.doing_handshake:
             return
         try:
             self.on_update()
@@ -413,6 +421,7 @@ class GenericWidget:
         except Exception as e:
             serial_success = False
             self.parent_dashboard.exc_handler(e,'serial build',self.name)
+
         if not serial_success:
             if not self.no_serial:
                 self.do_threadsafe(lambda: self.serial_status.set("Connection Failed"))


### PR DESCRIPTION
As discussed in email, this patch should solve the issue of widget being unable to share threads. It is current **UNTESTED** but will be tested tomorrow morning. Just pushing up for visibility now.